### PR TITLE
Fix typo in the RPM package link

### DIFF
--- a/extension/src/setup/instructions.js
+++ b/extension/src/setup/instructions.js
@@ -41,7 +41,7 @@ async function prepareInstallInstructions () {
       case 'x86-32':
         return 'i686'
       case 'x86-64':
-        return 'x84_64'
+        return 'x86_64'
       case 'arm':
         return 'armv7hl'
       case 'arm64':


### PR DESCRIPTION
The link for the RPM package had "x84_64" instead of "x86_64"