### PR TITLE
Update outdated winget step in instructions.html

### DIFF
--- a/extension/src/setup/instructions.html
+++ b/extension/src/setup/instructions.html
@@ -34,7 +34,7 @@
             <span><em>Or...</em> To install the package using Windows Package Manager:</span>
             <ol>
               <li>Make sure <a href="https://github.com/microsoft/winget-cli#installing-the-client" target="_blank">Windows Package Manager</a> is installed.</li>
-              <li>Install Visual C++ Redistributable using winget: <kbd>winget install -e Microsoft.VC++2015-2022Redist-<span id="connector-crt-arch"></span></kbd>.</li>
+              <li>Install Visual C++ Redistributable using winget: <kbd>winget install -e Microsoft.VCRedist.2015+.<span id="connector-crt-arch"></span></kbd>.</li>
               <li>Install PWAsForFirefox using winget: <kbd>winget install firefoxpwa --version <span class="connector-project-version"></span></kbd></li>
               <li>After the packages are installed, you should be automatically proceeded to the next step. If nothing changes after around 30 seconds, restart the browser.</li>
             </ol>


### PR DESCRIPTION
This step in the current winget instruction don't work anymore
```
Install Visual C++ Redistributable using winget: winget install -e Microsoft.VC++2015-2022Redist-x64.
```
It seems like someone may have renamed the winget package

![image](https://user-images.githubusercontent.com/3873011/210139163-54640782-ffe5-485c-a5e4-6f63644a89d1.png)