### PR TITLE
Fix write permissions for runtime autoconfig files

### DIFF
--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -46,7 +46,7 @@ cfg_if! {
             let path = target.join(path);
 
             if let Err(_e) = set_permissions(path, PermissionsExt::from_mode(0o644)) {
-                info!("Failed to make patch writable")
+                warn!("Failed to make patch writable")
             }
         }
     }


### PR DESCRIPTION
Hi! Your great tool is currently being packaged in NixOS (https://github.com/NixOS/nixpkgs/pull/215905), and it seems that the ```autoconfig.js``` and ```_autoconfig.cfg``` files are problematic.

Because the source files are write-only on NixOS, when they're copied to the ```runtime``` folder at each launch they make  ```firefoxpwa``` crash with "PermissionDenied" error (13), as soon as we want to use more than one profile.

So this would be a suggestion to force these files to be writable each time they're copied. I tried not to use ```walkdir``` to avoid modifying ```Cargo.toml```, so I hope there won't be compatibility issues platform-wise.