### PR TITLE
Add new set-version task to native Makefile.toml

### DIFF
--- a/extension/src/setup/instructions.html
+++ b/extension/src/setup/instructions.html
@@ -151,8 +151,7 @@
             <li>Make sure <a href="https://github.com/sagiegurari/cargo-make" target="_blank"><kbd>cargo-make</kbd></a> and (on Windows) <a href="https://wixtoolset.org/releases/" target="_blank">WiX Toolset</a> are installed.</li>
             <li>Clone the <a href="https://github.com/filips123/PWAsForFirefox" target="_blank">repository</a> and <kbd>cd</kbd> into the <kbd>native</kbd> directory.</li>
             <li>Checkout the <kbd class="connector-repository-tag"></kbd> tag.</li>
-            <li>Modify <kbd>version</kbd> field inside <kbd>Cargo.toml</kbd> to <kbd class="connector-project-version"></kbd>.</li>
-            <li>Modify <kbd>DISTRIBUTION_VERSION</kbd> variable inside <kbd>userchrome/profile/chrome/pwa/chrome.jsm</kbd> to <kbd class="connector-project-version"></kbd>.</li>
+            <li>Prepare the source code for building: <kbd>makers set-version</kbd></li>
             <li>Build and install the project: <kbd>makers install</kbd></li>
             <li>After the project is installed, you should be automatically proceeded to the next step. If nothing changes after around 30 seconds, restart the browser.</li>
           </ol>

--- a/native/Makefile.toml
+++ b/native/Makefile.toml
@@ -76,38 +76,4 @@ script = [
 [tasks.set-version]
 description = "Set version to given version or current git tag"
 script_runner="@duckscript"
-script = """
-if ${1}
-    # Use first argument
-    pwa_ver = set ${1}
-else
-    # No argument, find tag from git
-    git_tag = exec git describe --tags --abbrev=0
-    assert_eq ${git_tag.code} 0 "No version provided to task and unable to retrieve git tag"
-    pwa_ver = trim ${git_tag.stdout}
-    release git_tag
-    unset git_tag
-end
-# Remove single leading v if it exists
-if starts_with ${pwa_ver} "v"
-    pwa_ver = substring ${pwa_ver} 1
-end
-cargo_toml_path = set "./Cargo.toml"
-chrome_jsm_path = set "./userchrome/profile/chrome/pwa/chrome.jsm"
-cargo_toml_exists = is_file ${cargo_toml_path}
-chrome_jsm_exists = is_file ${chrome_jsm_path}
-if ${cargo_toml_exists} and ${chrome_jsm_exists}
-    cargo_toml_replace = concat "version = \\"" ${pwa_ver} "\\""
-    chrome_jsm_replace = concat "DISTRIBUTION_VERSION = '" ${pwa_ver} "'"
-    cargo_toml = readfile ${cargo_toml_path}
-    chrome_jsm = readfile ${chrome_jsm_path}
-    echo "Replacing" ${cargo_toml_replace}
-    cargo_toml = replace ${cargo_toml} "version = \\"0.0.0\\"" ${cargo_toml_replace}
-    echo "Replacing" ${chrome_jsm_replace}
-    chrome_jsm = replace ${chrome_jsm} "DISTRIBUTION_VERSION = '0.0.0'" ${chrome_jsm_replace}
-    writefile ${cargo_toml_path} ${cargo_toml}
-    writefile ${chrome_jsm_path} ${chrome_jsm}
-else
-    assert_fail "Unable to locate ./Cargo.toml and ./userchrome/profile/chrome/pwa/chrome.jsm"
-end
-"""
+script = "!include_files ./set-version.ds"

--- a/native/Makefile.toml
+++ b/native/Makefile.toml
@@ -70,3 +70,44 @@ script = [
     "echo FATAL: This environment does not support automatic installation using cargo-make",
     "exit 1"
 ]
+
+### OTHERS ###
+
+[tasks.set-version]
+description = "Set version to given version or current git tag"
+script_runner="@duckscript"
+script = """
+if ${1}
+    # Use first argument
+    pwa_ver = set ${1}
+else
+    # No argument, find tag from git
+    git_tag = exec git describe --tags --abbrev=0
+    assert_eq ${git_tag.code} 0 "No version provided to task and unable to retrieve git tag"
+    pwa_ver = trim ${git_tag.stdout}
+    release git_tag
+    unset git_tag
+end
+# Remove single leading v if it exists
+if starts_with ${pwa_ver} "v"
+    pwa_ver = substring ${pwa_ver} 1
+end
+cargo_toml_path = set "./Cargo.toml"
+chrome_jsm_path = set "./userchrome/profile/chrome/pwa/chrome.jsm"
+cargo_toml_exists = is_file ${cargo_toml_path}
+chrome_jsm_exists = is_file ${chrome_jsm_path}
+if ${cargo_toml_exists} and ${chrome_jsm_exists}
+    cargo_toml_replace = concat "version = \\"" ${pwa_ver} "\\""
+    chrome_jsm_replace = concat "DISTRIBUTION_VERSION = '" ${pwa_ver} "'"
+    cargo_toml = readfile ${cargo_toml_path}
+    chrome_jsm = readfile ${chrome_jsm_path}
+    echo "Replacing" ${cargo_toml_replace}
+    cargo_toml = replace ${cargo_toml} "version = \\"0.0.0\\"" ${cargo_toml_replace}
+    echo "Replacing" ${chrome_jsm_replace}
+    chrome_jsm = replace ${chrome_jsm} "DISTRIBUTION_VERSION = '0.0.0'" ${chrome_jsm_replace}
+    writefile ${cargo_toml_path} ${cargo_toml}
+    writefile ${chrome_jsm_path} ${chrome_jsm}
+else
+    assert_fail "Unable to locate ./Cargo.toml and ./userchrome/profile/chrome/pwa/chrome.jsm"
+end
+"""

--- a/native/README.md
+++ b/native/README.md
@@ -83,8 +83,7 @@ cd PWAsForFirefox/native
 # Set the VERSION environment variable
 # And run the following commands to set version
 git checkout tags/v${VERSION}
-sed -i "s/version = \"0.0.0\"/version = \"$VERSION\"/g" Cargo.toml
-sed -i "s/DISTRIBUTION_VERSION = '0.0.0'/DISTRIBUTION_VERSION = '$VERSION'/g" userchrome/profile/chrome/pwa/chrome.jsm
+makers set-version ${VERSION}
 
 # Build and install the project
 makers install

--- a/native/set-version.ds
+++ b/native/set-version.ds
@@ -1,0 +1,52 @@
+# For Makefile.toml, but could be run on its own
+# Sets version strings in configuration files to first argument or from git
+
+fn <scope> replace_version
+    content = set ${1}
+    version_find = set ${2}
+    pwa_ver = set ${3}
+    quote_find = set ${4}
+    version_find_length = strlen ${version_find}
+    back_index = indexof ${content} ${version_find}
+    back_index = calc ${back_index} + ${version_find_length}
+    back = substring ${content} ${back_index}
+    back_length = strlen ${back}
+    front = substring ${content} -${back_length}
+    quote_find_index = indexof ${back} ${quote_find}
+    back = substring ${back} ${quote_find_index}
+    content = concat ${front} ${pwa_ver} ${back}
+    return ${content}
+end
+
+if ${1}
+    # Use first argument
+    pwa_ver = set ${1}
+else
+    # No argument, find tag from git
+    git_tag = exec git describe --tags --abbrev=0
+    assert_eq ${git_tag.code} 0 "No version provided to task and unable to retrieve git tag"
+    pwa_ver = trim ${git_tag.stdout}
+    release git_tag
+    unset git_tag
+end
+# Remove single leading v if it exists
+if starts_with ${pwa_ver} "v"
+    pwa_ver = substring ${pwa_ver} 1
+end
+
+cargo_toml_path = set "./Cargo.toml"
+chrome_jsm_path = set "./userchrome/profile/chrome/pwa/chrome.jsm"
+cargo_toml_exists = is_file ${cargo_toml_path}
+chrome_jsm_exists = is_file ${chrome_jsm_path}
+if ${cargo_toml_exists} and ${chrome_jsm_exists}
+    echo "Replacing version = \"${pwa_ver}\""
+    cargo_toml = readfile ${cargo_toml_path}
+    cargo_toml = replace_version ${cargo_toml} "# Version will be set by CI from the Git tag when building and releasing\nversion = \"" ${pwa_ver} "\""
+    writefile ${cargo_toml_path} ${cargo_toml}
+    echo "Replacing DISTRIBUTION_VERSION = '${pwa_ver}'"
+    chrome_jsm = readfile ${chrome_jsm_path}
+    chrome_jsm = replace_version ${chrome_jsm} "DISTRIBUTION_VERSION = '" ${pwa_ver} "'"
+    writefile ${chrome_jsm_path} ${chrome_jsm}
+else
+    assert_fail "Unable to locate ./Cargo.toml and ./userchrome/profile/chrome/pwa/chrome.jsm"
+end


### PR DESCRIPTION
New duckscript task to set the version number when building from source yourself
You can now run for example `makers set-version 2.7.2` to set the version in the native code to 2.7.2
You can also run `makers set-version` without argument to automatically fetch the closest git tag using [`git describe`](https://git-scm.com/docs/git-describe/2.41.0).

This does not cause the `build` task to depend on `set-version`. ~~Also, as it is now the task cannot update the version multiple times, and the source code must be reset to update it again. This is because I have stuck to the behavior of other scripts within the source code so far which also only can update once, but it could be improved if needed.~~

Documentation for building from source within the extension and in native/README.md are also updated.

Addresses the native portion of #193