### PR TITLE
Add set-version yarn script to extension 

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -29,8 +29,7 @@ Note that these are development versions that may be unstable and are not signed
 
 3. If building a specific version:
     1. Checkout the correct Git tag.
-    2. Modify `version` field inside `package.json` to the correct version.
-    3. Modify `version` field inside `src/manifest.json` to the correct version.
+    2. Run `yarn set-version` to add the version information to the configuration files.
 
 4. Either:
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -27,7 +27,8 @@
     "fix": "run-s -c fix:*",
     "fix:eslint": "eslint --fix src icons",
     "prepare:clean": "rimraf dist",
-    "prepare:icons": "node ./icons/generate.js"
+    "prepare:icons": "node ./icons/generate.js",
+    "set-version": "node ./set-version.js"
   },
   "dependencies": {
     "@popperjs/core": "^2.11.6",

--- a/extension/set-version.js
+++ b/extension/set-version.js
@@ -1,0 +1,50 @@
+const { execSync } = require('child_process');
+const { accessSync, constants: {F_OK, R_OK, W_OK}, readFileSync, writeFileSync } = require('fs');
+
+const packagePath = './package.json';
+const manifestPath = './src/manifest.json';
+const neededPermissions = F_OK | R_OK | W_OK;
+
+var pwaVersion = '';
+var packageText = '';
+var manifestText = '';
+var package;
+var manifest;
+
+if (process.argv.length >= 3) {
+  // Use first argument
+  pwaVersion = process.argv[2].toString();
+} else {
+  try {
+    // No argument, try to find from git
+    pwaVersion = execSync('git describe --tags --abbrev=0').toString();
+  } catch (err) {
+    console.error('No version provided and unable to retrieve git tag');
+    throw err;
+  }
+}
+
+// Remove single leading v if it exists
+pwaVersion = pwaVersion.trim().replace(/^v(.+)$/, '$1')
+
+try {
+    accessSync(packagePath, neededPermissions);
+    accessSync(manifestPath, neededPermissions);
+} catch (err) {
+  console.error('Unable to access ./package.json and ./src/manifest.json');
+  throw err;
+}
+
+console.error(`Editing package.json version: '${pwaVersion}'`);
+packageText = readFileSync(packagePath).toString();
+package = JSON.parse(packageText);
+package.version = pwaVersion;
+packageText = JSON.stringify(package, null, 2);
+writeFileSync(packagePath, packageText);
+
+console.error(`Editing manifest.json version: '${pwaVersion}'`);
+manifestText = readFileSync(manifestPath).toString();
+manifest = JSON.parse(manifestText);
+manifest.version = pwaVersion;
+manifestText = JSON.stringify(manifest, null, 2);
+writeFileSync(manifestPath, manifestText);


### PR DESCRIPTION
New node.js script in package.json to set the version number when building from source yourself
You can run `yarn set-version 2.7.2` to set the version in the extension config files to 2.7.2
Or, you can run `yarn set-version` without arguments to automatically fetch the closest git tag using [`git describe`](https://git-scm.com/docs/git-describe/2.41.0).

Documentation for building the extension from source in extension/README.md has been updated to suggest `yarn set-version` rather than editing the versions by hand

Addresses the extension portion of #193 
The extension counterpart to #371

(Yes, the two PRs are very similar, it's done that way to be funny 😄)