### PR TITLE
Add initial support for link flag

### DIFF
--- a/extension/src/sites/manage.js
+++ b/extension/src/sites/manage.js
@@ -865,12 +865,6 @@ async function handleSettings (hasChanged = false) {
     this.disabled = true
     this.innerText = await getMessage('buttonReinstallProcessing')
 
-    // Listen for use Linked runtime
-    document.getElementById('settings-use-linked-runtime').addEventListener('change', async function () {
-      config.use_linked_runtime = this.checked
-      await setConfig(config)
-    })
-
     const responseUninstall = await browser.runtime.sendNativeMessage('firefoxpwa', { cmd: 'UninstallRuntime' })
     if (responseUninstall.type === 'Error') throw new Error(responseUninstall.data)
     if (responseUninstall.type !== 'RuntimeUninstalled') throw new Error(`Received invalid response type: ${responseUninstall.type}`)
@@ -919,7 +913,6 @@ async function handleSettings (hasChanged = false) {
       document.getElementById('settings-enable-wayland-container').classList.remove('d-none')
       document.getElementById('settings-use-xinput2-container').classList.remove('d-none')
       document.getElementById('settings-use-portals-container').classList.remove('d-none')
-      document.getElementById('settings-use-linked-runtime-container').classList.remove('d-none')
     }
 
     // Hide patching setting on macOS
@@ -934,7 +927,6 @@ async function handleSettings (hasChanged = false) {
     document.getElementById('settings-enable-wayland').checked = config.runtime_enable_wayland
     document.getElementById('settings-use-xinput2').checked = config.runtime_use_xinput2
     document.getElementById('settings-use-portals').checked = config.runtime_use_portals
-    document.getElementById('settings-use-linked-runtime').checked = config.use_linked_runtime
     document.getElementById('settings-always-patch').checked = config.always_patch
 
     // Enable settings inputs
@@ -945,7 +937,6 @@ async function handleSettings (hasChanged = false) {
     document.getElementById('settings-enable-wayland').disabled = false
     document.getElementById('settings-use-xinput2').disabled = false
     document.getElementById('settings-use-portals').disabled = false
-    document.getElementById('settings-use-linked-runtime').disabled = false
     document.getElementById('settings-always-patch').disabled = false
 
     // Helper function to update config

--- a/extension/src/sites/manage.js
+++ b/extension/src/sites/manage.js
@@ -865,6 +865,12 @@ async function handleSettings (hasChanged = false) {
     this.disabled = true
     this.innerText = await getMessage('buttonReinstallProcessing')
 
+    // Listen for use Linked runtime
+    document.getElementById('settings-use-linked-runtime').addEventListener('change', async function () {
+      config.use_linked_runtime = this.checked
+      await setConfig(config)
+    })
+
     const responseUninstall = await browser.runtime.sendNativeMessage('firefoxpwa', { cmd: 'UninstallRuntime' })
     if (responseUninstall.type === 'Error') throw new Error(responseUninstall.data)
     if (responseUninstall.type !== 'RuntimeUninstalled') throw new Error(`Received invalid response type: ${responseUninstall.type}`)
@@ -913,6 +919,7 @@ async function handleSettings (hasChanged = false) {
       document.getElementById('settings-enable-wayland-container').classList.remove('d-none')
       document.getElementById('settings-use-xinput2-container').classList.remove('d-none')
       document.getElementById('settings-use-portals-container').classList.remove('d-none')
+      document.getElementById('settings-use-linked-runtime-container').classList.remove('d-none')
     }
 
     // Hide patching setting on macOS
@@ -927,6 +934,7 @@ async function handleSettings (hasChanged = false) {
     document.getElementById('settings-enable-wayland').checked = config.runtime_enable_wayland
     document.getElementById('settings-use-xinput2').checked = config.runtime_use_xinput2
     document.getElementById('settings-use-portals').checked = config.runtime_use_portals
+    document.getElementById('settings-use-linked-runtime').checked = config.use_linked_runtime
     document.getElementById('settings-always-patch').checked = config.always_patch
 
     // Enable settings inputs
@@ -937,6 +945,7 @@ async function handleSettings (hasChanged = false) {
     document.getElementById('settings-enable-wayland').disabled = false
     document.getElementById('settings-use-xinput2').disabled = false
     document.getElementById('settings-use-portals').disabled = false
+    document.getElementById('settings-use-linked-runtime').disabled = false
     document.getElementById('settings-always-patch').disabled = false
 
     // Helper function to update config

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -204,6 +204,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 
 [[package]]
+name = "blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "brotli"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +402,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 
 [[package]]
 name = "core-foundation"
@@ -639,6 +658,7 @@ version = "0.0.0"
 dependencies = [
  "ab_glyph",
  "anyhow",
+ "blake3",
  "byteorder",
  "bzip2",
  "cfg-if",

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -27,6 +27,7 @@ immutable-runtime = []
 [dependencies]
 ab_glyph = "0.2.23"
 anyhow = "1.0.79"
+blake3 = "1.5.0"
 byteorder = "1.5.0"
 cfg-if = "1.0.0"
 clap = { version = "^4.4.18", features = ["derive"] }

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -23,11 +23,11 @@ lto = true
 portable = ["dep:phf"]
 static = ["reqwest/native-tls-vendored", "bzip2/static"]
 immutable-runtime = []
+linked-runtime = ["dep:blake3"]
 
 [dependencies]
 ab_glyph = "0.2.23"
 anyhow = "1.0.79"
-blake3 = "1.5.0"
 byteorder = "1.5.0"
 cfg-if = "1.0.0"
 clap = { version = "^4.4.18", features = ["derive"] }
@@ -76,6 +76,7 @@ features = [
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 glob = "0.3.1"
 phf = { version = "0.11.2", features = ["macros"] }
+blake3 = { version = "1.5.0", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 bzip2 = "0.4.4"

--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -296,9 +296,7 @@ impl Runtime {
         let dirs = ProjectDirs::new()?;
         let mut storage = Storage::load(&dirs)?;
 
-        if !storage.config.use_linked_runtime {
-            self.uninstall()?;
-        }
+        self.uninstall()?;
 
         storage.config.use_linked_runtime = true;
         storage.write(&dirs)?;

--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -289,7 +289,7 @@ impl Runtime {
         Ok(())
     }
 
-    #[cfg(all(any(target_os = "linux", target_os = "bsd"), not(feature = "immutable-runtime")))]
+    #[cfg(any(target_os = "linux", target_os = "bsd"))]
     pub fn link(&self) -> Result<()> {
         use crate::storage::Storage;
         use std::fs::{copy, create_dir_all};

--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -198,7 +198,7 @@ impl Runtime {
         const COPY_ERROR: &str = "Failed to copy the runtime";
         const CLEANUP_ERROR: &str = "Failed to clean up the runtime";
 
-        #[cfg(target_os = "linux")]
+        #[cfg(feature = "linked-runtime")]
         {
             use crate::storage::Storage;
 
@@ -289,7 +289,7 @@ impl Runtime {
         Ok(())
     }
 
-    #[cfg(any(target_os = "linux", target_os = "bsd"))]
+    #[cfg(feature = "linked-runtime")]
     pub fn link(&self) -> Result<()> {
         use crate::storage::Storage;
         use std::fs::{copy, create_dir_all};

--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -110,9 +110,9 @@ fn get_download_url() -> &'static str {
 pub struct Runtime {
     pub version: Option<String>,
 
-    directory: PathBuf,
-    executable: PathBuf,
-    config: PathBuf,
+    pub directory: PathBuf,
+    pub executable: PathBuf,
+    pub config: PathBuf,
 }
 
 impl Runtime {
@@ -291,9 +291,10 @@ impl Runtime {
 
     #[cfg(feature = "linked-runtime")]
     pub fn link(&self) -> Result<()> {
-        use crate::storage::Storage;
         use std::fs::{copy, create_dir_all};
         use std::os::unix::fs::symlink;
+
+        use crate::storage::Storage;
 
         let dirs = ProjectDirs::new()?;
         let mut storage = Storage::load(&dirs)?;

--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -1,10 +1,9 @@
-use std::fs::{read_dir, remove_dir_all, remove_file, File};
-use std::io::{Read, Result as IoResult};
+use std::fs::{read_dir, remove_dir_all, remove_file};
+use std::io::Result as IoResult;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command};
 
 use anyhow::{anyhow, Context, Result};
-use blake3::Hasher;
 use cfg_if::cfg_if;
 use configparser::ini::Ini;
 use fs_extra::dir::{copy, CopyOptions};
@@ -16,14 +15,6 @@ use crate::directories::ProjectDirs;
 
 // TODO: Remove this constant and implement variable firefox path into user documentation
 pub const FFOX: &str = "/usr/lib/firefox/";
-
-pub fn b3hasher() -> String {
-    let mut file = File::open(Path::new(FFOX).join("firefox")).unwrap();
-    let mut buf = Vec::new();
-    let _ = file.read_to_end(&mut buf);
-
-    Hasher::new().update(&buf).finalize().to_string()
-}
 
 cfg_if! {
     if #[cfg(any(platform_linux, platform_bsd))] {
@@ -330,10 +321,6 @@ impl Runtime {
                     }
                     Some("firefox") => {
                         copy(entry, self.directory.join("firefox"))?;
-
-                        storage.config.hash = b3hasher();
-
-                        trace!("Hash: {}", b3hasher());
                     }
                     Some(&_) => {
                         let link = self.directory.join(entry.file_name().unwrap());

--- a/native/src/connector/process.rs
+++ b/native/src/connector/process.rs
@@ -83,7 +83,10 @@ impl Process for SetConfig {
 
 impl Process for InstallRuntime {
     fn process(&self, _connection: &Connection) -> Result<ConnectorResponse> {
-        let command = RuntimeInstallCommand {};
+        let command = RuntimeInstallCommand {
+            #[cfg(target_os = "linux")]
+            link: self.link,
+        };
         command.run()?;
 
         Ok(ConnectorResponse::RuntimeInstalled)

--- a/native/src/connector/process.rs
+++ b/native/src/connector/process.rs
@@ -4,16 +4,36 @@ use log::{info, warn};
 
 use crate::components::runtime::Runtime;
 use crate::connector::request::{
-    CreateProfile, GetConfig, GetProfileList, GetSiteList, GetSystemVersions, InstallRuntime,
-    InstallSite, LaunchSite, PatchAllProfiles, RegisterProtocolHandler, RemoveProfile, SetConfig,
-    UninstallRuntime, UninstallSite, UnregisterProtocolHandler, UpdateAllSites, UpdateProfile,
+    CreateProfile,
+    GetConfig,
+    GetProfileList,
+    GetSiteList,
+    GetSystemVersions,
+    InstallRuntime,
+    InstallSite,
+    LaunchSite,
+    PatchAllProfiles,
+    RegisterProtocolHandler,
+    RemoveProfile,
+    SetConfig,
+    UninstallRuntime,
+    UninstallSite,
+    UnregisterProtocolHandler,
+    UpdateAllSites,
+    UpdateProfile,
     UpdateSite,
 };
 use crate::connector::response::ConnectorResponse;
 use crate::connector::Connection;
 use crate::console::app::{
-    ProfileCreateCommand, ProfileRemoveCommand, ProfileUpdateCommand, RuntimeInstallCommand,
-    RuntimeUninstallCommand, SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand,
+    ProfileCreateCommand,
+    ProfileRemoveCommand,
+    ProfileUpdateCommand,
+    RuntimeInstallCommand,
+    RuntimeUninstallCommand,
+    SiteInstallCommand,
+    SiteLaunchCommand,
+    SiteUninstallCommand,
     SiteUpdateCommand,
 };
 use crate::console::Run;

--- a/native/src/connector/process.rs
+++ b/native/src/connector/process.rs
@@ -4,36 +4,16 @@ use log::{info, warn};
 
 use crate::components::runtime::Runtime;
 use crate::connector::request::{
-    CreateProfile,
-    GetConfig,
-    GetProfileList,
-    GetSiteList,
-    GetSystemVersions,
-    InstallRuntime,
-    InstallSite,
-    LaunchSite,
-    PatchAllProfiles,
-    RegisterProtocolHandler,
-    RemoveProfile,
-    SetConfig,
-    UninstallRuntime,
-    UninstallSite,
-    UnregisterProtocolHandler,
-    UpdateAllSites,
-    UpdateProfile,
+    CreateProfile, GetConfig, GetProfileList, GetSiteList, GetSystemVersions, InstallRuntime,
+    InstallSite, LaunchSite, PatchAllProfiles, RegisterProtocolHandler, RemoveProfile, SetConfig,
+    UninstallRuntime, UninstallSite, UnregisterProtocolHandler, UpdateAllSites, UpdateProfile,
     UpdateSite,
 };
 use crate::connector::response::ConnectorResponse;
 use crate::connector::Connection;
 use crate::console::app::{
-    ProfileCreateCommand,
-    ProfileRemoveCommand,
-    ProfileUpdateCommand,
-    RuntimeInstallCommand,
-    RuntimeUninstallCommand,
-    SiteInstallCommand,
-    SiteLaunchCommand,
-    SiteUninstallCommand,
+    ProfileCreateCommand, ProfileRemoveCommand, ProfileUpdateCommand, RuntimeInstallCommand,
+    RuntimeUninstallCommand, SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand,
     SiteUpdateCommand,
 };
 use crate::console::Run;
@@ -84,7 +64,7 @@ impl Process for SetConfig {
 impl Process for InstallRuntime {
     fn process(&self, _connection: &Connection) -> Result<ConnectorResponse> {
         let command = RuntimeInstallCommand {
-            #[cfg(target_os = "linux")]
+            #[cfg(feature = "linked-runtime")]
             link: self.link,
         };
         command.run()?;

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -154,14 +154,14 @@ pub struct SetConfig(pub Config);
 /// [`ConnectorResponse::RuntimeInstalled`] - No data.
 ///
 
-#[cfg(any(target_os = "linux", target_os = "bsd"))]
+#[cfg(feature = "linked-runtime")]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime {
     /// Experimental: use a linked runtime instead of downloading from mozilla.
     pub link: bool,
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "bsd")))]
+#[cfg(not(feature = "linked-runtime"))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime;
 
@@ -612,7 +612,7 @@ impl Into<crate::console::app::HTTPClientConfig> for HTTPClientConfig {
 
 deserialize_unit_struct!(GetSystemVersions);
 deserialize_unit_struct!(GetConfig);
-#[cfg(not(any(target_os = "linux", target_os = "bsd")))]
+#[cfg(not(feature = "linked-runtime"))]
 deserialize_unit_struct!(InstallRuntime);
 deserialize_unit_struct!(UninstallRuntime);
 deserialize_unit_struct!(GetSiteList);

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -157,7 +157,7 @@ pub struct SetConfig(pub Config);
 #[cfg(feature = "linked-runtime")]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime {
-    /// Experimental: use a linked runtime instead of downloading from mozilla.
+    /// Experimental: Use a linked runtime instead of downloading from Mozilla.
     pub link: bool,
 }
 

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -154,14 +154,14 @@ pub struct SetConfig(pub Config);
 /// [`ConnectorResponse::RuntimeInstalled`] - No data.
 ///
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "bsd"))]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime {
     /// Experimental: use a linked runtime instead of downloading from mozilla.
     pub link: bool,
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "bsd")))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime;
 
@@ -612,7 +612,7 @@ impl Into<crate::console::app::HTTPClientConfig> for HTTPClientConfig {
 
 deserialize_unit_struct!(GetSystemVersions);
 deserialize_unit_struct!(GetConfig);
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "bsd")))]
 deserialize_unit_struct!(InstallRuntime);
 deserialize_unit_struct!(UninstallRuntime);
 deserialize_unit_struct!(GetSiteList);

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -153,8 +153,12 @@ pub struct SetConfig(pub Config);
 ///
 /// [`ConnectorResponse::RuntimeInstalled`] - No data.
 ///
-#[derive(Debug, Eq, PartialEq, Clone)]
-pub struct InstallRuntime;
+#[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct InstallRuntime {
+    #[cfg(target_os = "linux")]
+    /// Experimental: use a linked runtime instead of downloading from mozilla.
+    pub link: bool,
+}
 
 /// Uninstalls the Firefox runtime.
 ///
@@ -603,6 +607,7 @@ impl Into<crate::console::app::HTTPClientConfig> for HTTPClientConfig {
 
 deserialize_unit_struct!(GetSystemVersions);
 deserialize_unit_struct!(GetConfig);
+#[cfg(not(target_os = "linux"))]
 deserialize_unit_struct!(InstallRuntime);
 deserialize_unit_struct!(UninstallRuntime);
 deserialize_unit_struct!(GetSiteList);

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -153,12 +153,17 @@ pub struct SetConfig(pub Config);
 ///
 /// [`ConnectorResponse::RuntimeInstalled`] - No data.
 ///
+
+#[cfg(target_os = "linux")]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime {
-    #[cfg(target_os = "linux")]
     /// Experimental: use a linked runtime instead of downloading from mozilla.
     pub link: bool,
 }
+
+#[cfg(not(target_os = "linux"))]
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct InstallRuntime;
 
 /// Uninstalls the Firefox runtime.
 ///

--- a/native/src/console/app.rs
+++ b/native/src/console/app.rs
@@ -276,7 +276,7 @@ pub enum RuntimeCommand {
 
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
 pub struct RuntimeInstallCommand {
-    /// Experimental: use a linked runtime instead of downloading from mozilla.
+    /// Experimental: Use a linked runtime instead of downloading from Mozilla
     #[cfg(feature = "linked-runtime")]
     #[clap(long)]
     pub link: bool,

--- a/native/src/console/app.rs
+++ b/native/src/console/app.rs
@@ -277,7 +277,7 @@ pub enum RuntimeCommand {
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
 pub struct RuntimeInstallCommand {
     /// Experimental: use a linked runtime instead of downloading from mozilla.
-    #[cfg(any(target_os = "linux", target_os = "bsd"))]
+    #[cfg(feature = "linked-runtime")]
     #[clap(long)]
     pub link: bool,
 }

--- a/native/src/console/app.rs
+++ b/native/src/console/app.rs
@@ -277,7 +277,7 @@ pub enum RuntimeCommand {
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
 pub struct RuntimeInstallCommand {
     /// Experimental: use a linked runtime instead of downloading from mozilla.
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "bsd"))]
     #[clap(long)]
     pub link: bool,
 }

--- a/native/src/console/app.rs
+++ b/native/src/console/app.rs
@@ -275,7 +275,12 @@ pub enum RuntimeCommand {
 }
 
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
-pub struct RuntimeInstallCommand {}
+pub struct RuntimeInstallCommand {
+    /// Experimental: use a linked runtime instead of downloading from mozilla.
+    #[cfg(target_os = "linux")]
+    #[clap(long)]
+    pub link: bool,
+}
 
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
 pub struct RuntimeUninstallCommand {}

--- a/native/src/console/runtime.rs
+++ b/native/src/console/runtime.rs
@@ -26,7 +26,7 @@ impl Run for RuntimeInstallCommand {
         let dirs = ProjectDirs::new()?;
         let runtime = Runtime::new(&dirs)?;
 
-        if cfg!(any(linux, bsd)) && self.link {
+        if cfg!(any(target_os = "linux", target_os = "bsd")) && self.link {
             runtime.link().context("Failed to link runtime")?
         } else {
             runtime.install().context("Failed to install runtime")?;

--- a/native/src/console/runtime.rs
+++ b/native/src/console/runtime.rs
@@ -25,7 +25,16 @@ impl Run for RuntimeInstallCommand {
 
         let dirs = ProjectDirs::new()?;
         let runtime = Runtime::new(&dirs)?;
-        runtime.install().context("Failed to install runtime")?;
+
+        cfg_if! {
+            if #[cfg(target_os = "linux")] {
+                if self.link {
+                    runtime.link().context("Failed to link runtime")?
+                }
+            } else {
+                runtime.install().context("Failed to install runtime")?;
+            }
+        };
 
         let runtime = Runtime::new(&dirs)?;
         runtime.patch(&dirs, None)?;

--- a/native/src/console/runtime.rs
+++ b/native/src/console/runtime.rs
@@ -26,15 +26,11 @@ impl Run for RuntimeInstallCommand {
         let dirs = ProjectDirs::new()?;
         let runtime = Runtime::new(&dirs)?;
 
-        cfg_if! {
-            if #[cfg(target_os = "linux")] {
-                if self.link {
-                    runtime.link().context("Failed to link runtime")?
-                }
-            } else {
-                runtime.install().context("Failed to install runtime")?;
-            }
-        };
+        if cfg!(any(linux, bsd)) && self.link {
+            runtime.link().context("Failed to link runtime")?
+        } else {
+            runtime.install().context("Failed to install runtime")?;
+        }
 
         let runtime = Runtime::new(&dirs)?;
         runtime.patch(&dirs, None)?;

--- a/native/src/console/runtime.rs
+++ b/native/src/console/runtime.rs
@@ -26,11 +26,15 @@ impl Run for RuntimeInstallCommand {
         let dirs = ProjectDirs::new()?;
         let runtime = Runtime::new(&dirs)?;
 
-        if cfg!(any(target_os = "linux", target_os = "bsd")) && self.link {
+        #[cfg(feature = "linked-runtime")]
+        if self.link {
             runtime.link().context("Failed to link runtime")?
         } else {
             runtime.install().context("Failed to install runtime")?;
         }
+
+        #[cfg(not(feature = "linked-runtime"))]
+        runtime.install().context("Failed to install runtime")?;
 
         let runtime = Runtime::new(&dirs)?;
         runtime.patch(&dirs, None)?;

--- a/native/src/console/site.rs
+++ b/native/src/console/site.rs
@@ -12,17 +12,14 @@ use url::Url;
 use crate::components::runtime::Runtime;
 use crate::components::site::{Site, SiteConfig};
 use crate::console::app::{
-    SiteInstallCommand,
-    SiteLaunchCommand,
-    SiteUninstallCommand,
-    SiteUpdateCommand,
+    SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand, SiteUpdateCommand,
 };
 use crate::console::{store_value, store_value_vec, Run};
 use crate::directories::ProjectDirs;
-use crate::integrations;
 use crate::integrations::{IntegrationInstallArgs, IntegrationUninstallArgs};
 use crate::storage::Storage;
 use crate::utils::construct_certificates_and_client;
+use crate::{components, integrations};
 
 impl Run for SiteLaunchCommand {
     fn run(&self) -> Result<()> {
@@ -48,6 +45,11 @@ impl Run for SiteLaunchCommand {
 
         if runtime.version.is_none() {
             bail!("Runtime not installed");
+        }
+
+        if storage.config.hash != components::runtime::b3hasher() && !storage.config.hash.is_empty()
+        {
+            runtime.link()?;
         }
 
         // Patching on macOS is always needed to correctly show the web app name

--- a/native/src/storage.rs
+++ b/native/src/storage.rs
@@ -48,6 +48,11 @@ pub struct Config {
     /// Only affects Linux, on supported desktop environments.
     /// May be overwritten with a system environment variable.
     pub runtime_use_portals: bool,
+
+    #[cfg(target_os = "linux")]
+    /// Experimental: Using the system runtime to save some disk space.
+    /// This might not work on your system.
+    pub use_linked_runtime: bool,
 }
 
 #[non_exhaustive]

--- a/native/src/storage.rs
+++ b/native/src/storage.rs
@@ -53,7 +53,6 @@ pub struct Config {
     /// Experimental: Using the system runtime to save some disk space.
     /// This might not work on your system.
     pub use_linked_runtime: bool,
-    pub hash: String,
 }
 
 #[non_exhaustive]

--- a/native/src/storage.rs
+++ b/native/src/storage.rs
@@ -49,7 +49,7 @@ pub struct Config {
     /// May be overwritten with a system environment variable.
     pub runtime_use_portals: bool,
 
-    #[cfg(any(target_os = "linux", target_os = "bsd"))]
+    #[cfg(feature = "linked-runtime")]
     /// Experimental: Using the system runtime to save some disk space.
     /// This might not work on your system.
     pub use_linked_runtime: bool,

--- a/native/src/storage.rs
+++ b/native/src/storage.rs
@@ -49,10 +49,11 @@ pub struct Config {
     /// May be overwritten with a system environment variable.
     pub runtime_use_portals: bool,
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "bsd"))]
     /// Experimental: Using the system runtime to save some disk space.
     /// This might not work on your system.
     pub use_linked_runtime: bool,
+    pub hash: String,
 }
 
 #[non_exhaustive]


### PR DESCRIPTION
The link flag implement a mechanism (only for linux at the moment) to avoid downloading firefox from the mozilla server. Instead it will symlink to the distro installed one

- [ ] Embrace more cases (recognise developer-edition and others archs).
- [ ] I need help for fixing the connector in the GUI, at the moment is broken.
- [X] TUI works well.