### PR TITLE
Check for secure context before installing web app

### DIFF
--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -44,7 +44,7 @@ browser.notifications.onClicked.addListener(async notification => {
 // == CONTENT SCRIPT HANDLING
 
 // Detect manifest sent from content script
-browser.runtime.onMessage.addListener(async ({ manifestUrl, documentUrl }, { tab }) => {
+browser.runtime.onMessage.addListener(async ({ manifestUrl, documentUrl, isSecureContext }, { tab }) => {
   manifestUrl = manifestUrl ? new URL(manifestUrl) : undefined
   documentUrl = documentUrl ? new URL(documentUrl) : undefined
 
@@ -56,8 +56,8 @@ browser.runtime.onMessage.addListener(async ({ manifestUrl, documentUrl }, { tab
       return
   }
 
-  // If both manifest and the page are loaded over HTTPS, site is a valid web app
-  let isValidPwa = manifestUrl && manifestUrl.protocol === 'https:' && documentUrl.protocol === 'https:'
+  // If both manifest and the page are loaded over HTTPS, and we are in a secure context, site is a valid web app
+  let isValidPwa = manifestUrl && manifestUrl.protocol === 'https:' && documentUrl.protocol === 'https:' && isSecureContext
 
   // Force show or hide the page action depending on user preference
   const settingsDisplayPageAction = (await browser.storage.local.get(PREF_DISPLAY_PAGE_ACTION))[PREF_DISPLAY_PAGE_ACTION]

--- a/extension/src/content.js
+++ b/extension/src/content.js
@@ -4,8 +4,8 @@ const isAppleMaskIcon = link => link.getAttribute('rel').toLowerCase().includes(
 const manifestElement = document.querySelector('link[rel=manifest]')
 const manifestUrl = manifestElement ? new URL(manifestElement.getAttribute('href'), document.baseURI) : null
 
-// Send the initial manifest and document URLs on the page load
-browser.runtime.sendMessage({ manifestUrl: manifestUrl?.href, documentUrl: document.location.href })
+// Send the secure context state, initial manifest and document URLs on the page load
+browser.runtime.sendMessage({ manifestUrl: manifestUrl?.href, documentUrl: document.location.href, isSecureContext })
 
 // Send the current manifest and document URLs on request
 browser.runtime.onMessage.addListener((message, _, sendResponse) => {


### PR DESCRIPTION
PWA should only be installable in a secure context: https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#secure_context

Initially, I wanted the replace the current https check by secure context, because I couldn't install a PWA from localhost. But it turned out to be more complicated than this, because then we could load the manifest over http.
But checking for secure context in itself is still probably a good thing to do