### PR TITLE
Fix typo in features description

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ For more details and technical documentation about setting up, using, and develo
 
 * Command-line tool to install, manage and run Progressive Web Apps in Firefox.
 * Extension to set up native programs, and install, manage and run PWAs and their profiles directly from the main Firefox browser.
-* Isolated Firefox installation and profile(s) that stores the PWAs.
+* Isolated Firefox installation and profile(s) that store the PWAs.
 * Installed PWAs have their own start/app menu entry and taskbar icon, and live in their own window.
-* Installed PWAs have tabs and address bar for a better app-like feel.
+* Installed PWAs have no tabs and address bar for a better app-like feel.
 * Support for installing all websites as Progressive Web Apps.
 * Support for all Firefox addons/extensions and built-in Firefox features.
 * Support for automatic (user-triggered) installation and patching of installation and profile(s).

--- a/docs/docs/about/supported-features.md
+++ b/docs/docs/about/supported-features.md
@@ -14,9 +14,9 @@
 
 * Command-line tool to install, manage and run Progressive Web Apps in Firefox.
 * Extension to set up native programs, and install, manage and run PWAs and their profiles directly from the main Firefox browser.
-* Isolated Firefox installation and profile(s) that stores the PWAs.
+* Isolated Firefox installation and profile(s) that store the PWAs.
 * Installed PWAs have their own start/app menu entry and taskbar icon, and live in their own window.
-* Installed PWAs have tabs and address bar for a better app-like feel.
+* Installed PWAs have no tabs and address bar for a better app-like feel.
 * Support for installing all websites as Progressive Web Apps.
 * Support for all Firefox addons/extensions and built-in Firefox features.
 * Support for automatic (user-triggered) installation and patching of installation and profile(s).

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -77,9 +77,9 @@ please check [the help section](help/support.md), especially [the FAQ page](help
 
 * Command-line tool to install, manage and run Progressive Web Apps in Firefox.
 * Extension to set up native programs, and install, manage and run PWAs and their profiles directly from the main Firefox browser.
-* Isolated Firefox installation and profile(s) that stores the PWAs.
+* Isolated Firefox installation and profile(s) that store the PWAs.
 * Installed PWAs have their own start/app menu entry and taskbar icon, and live in their own window.
-* Installed PWAs have tabs and address bar for a better app-like feel.
+* Installed PWAs have no tabs and address bar for a better app-like feel.
 * Support for installing all websites as Progressive Web Apps.
 * Support for all Firefox addons/extensions and built-in Firefox features.
 * Support for automatic (user-triggered) installation and patching of installation and profile(s).


### PR DESCRIPTION
Clarify that PWAs actually show _no_ tabs or address bar and a drive-by verb-form fix.

Update the feature enumeration in both files where it's used.