### PR TITLE
Opening new main window on macOS uses about:blankhome

### DIFF
--- a/native/userchrome/profile/chrome/pwa/boot.jsm
+++ b/native/userchrome/profile/chrome/pwa/boot.jsm
@@ -184,14 +184,14 @@ nsDefaultCommandLineHandler.prototype.handle = function (cmdLine) {
 // This does not matter currently because of #81, but once it is fixed, this also needs to be reworked
 if (AppConstants.platform === 'macosx') {
   const { nsBrowserContentHandler } = Cu.import('resource:///modules/BrowserContentHandler.jsm');
-  nsBrowserContentHandler.prototype._getArgs = nsBrowserContentHandler.prototype.getArgs;
-  nsBrowserContentHandler.prototype.getArgs = function () {
+  nsBrowserContentHandler.prototype._getNewWindowArgs = nsBrowserContentHandler.prototype.getNewWindowArgs;
+  nsBrowserContentHandler.prototype.getNewWindowArgs = function () {
     if (globalThis.gFFPWASiteConfig) {
       const userStartUrl = globalThis.gFFPWASiteConfig.config.start_url;
       const manifestStartUrl = globalThis.gFFPWASiteConfig.manifest.start_url;
       return userStartUrl ? userStartUrl : manifestStartUrl;
     } else {
-      return this._getArgs(...arguments);
+      return this._getNewWindowArgs(...arguments);
     }
   }
 }


### PR DESCRIPTION
This should fix #593.

`nsBrowserContentHandler.prototype.getArguments` seems to have been removed, but there is now [`getNewWindowArgs`](https://searchfox.org/mozilla-central/source/browser/components/BrowserContentHandler.sys.mjs#742) and overriding that one fixes this bug for me.