### PR TITLE
Add Notion to Websites With Multiple Domains

### DIFF
--- a/docs/docs/resources/specific-website-tips.md
+++ b/docs/docs/resources/specific-website-tips.md
@@ -23,6 +23,7 @@ to change something in this list, please create a new issue or PR.
 | Microsoft, Outlook     | `login.live.com,login.microsoftonline.com` |
 | Proton                 | `account.proton.me`                        |
 | Spotify                | `accounts.spotify.com`                     |
+| Notion                 | `www.notion.com`                           |
 
 ## Websites With Invalid Manifests
 


### PR DESCRIPTION
Notion PWA (www.notion.so) would open www.notion.com/?cookie_sync_completed=true first time it's opened, and you would unfortunately get an empty window in the PWA. Though it would be fine when restarted.

Add `www.notion.com` to this list, to make it less confusing to users.