### PR TITLE
Build linked runtime by default

### DIFF
--- a/.github/workflows/native.yaml
+++ b/.github/workflows/native.yaml
@@ -455,7 +455,7 @@ jobs:
           path: signed/paf/*.paf.exe
           compression-level: 0
 
-      # == BUILD PROVENANCE
+      # == Build Provenance
 
       - name: Attest artifacts
         if: startsWith(github.ref, 'refs/tags/v')

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -38,16 +38,7 @@ fs_extra = "1.3.0"
 gag = "1.0.0"
 image = "0.25.5"
 log = "0.4.22"
-reqwest = { version = "0.12.11", features = [
-    "blocking",
-    "socks",
-    "gzip",
-    "brotli",
-    "zstd",
-    "deflate",
-    "native-tls",
-    "native-tls-alpn",
-] }
+reqwest = { version = "0.12.11", features = ["blocking", "socks", "gzip", "brotli", "zstd", "deflate", "native-tls", "native-tls-alpn"] }
 resvg = "0.44.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
@@ -79,7 +70,7 @@ features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",
     "Win32_UI_Shell_Common",
-    "Win32_UI_Shell_PropertiesSystem",
+    "Win32_UI_Shell_PropertiesSystem"
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
@@ -108,7 +99,10 @@ ulid = "1.1.3"
 url = "2.5.4"
 
 [package.metadata.wix]
-include = ["packages/wix/main.wxs", "packages/wix/userchrome.wxs"]
+include = [
+    "packages/wix/main.wxs",
+    "packages/wix/userchrome.wxs"
+]
 
 [package.metadata.deb]
 section = "web"
@@ -121,76 +115,28 @@ license-file = "packages/deb/copyright"
 revision = ""
 assets = [
     # Executables
-    [
-        "target/release/firefoxpwa",
-        "/usr/bin/firefoxpwa",
-        "755",
-    ],
-    [
-        "target/release/firefoxpwa-connector",
-        "/usr/libexec/firefoxpwa-connector",
-        "755",
-    ],
+    ["target/release/firefoxpwa", "/usr/bin/firefoxpwa", "755"],
+    ["target/release/firefoxpwa-connector", "/usr/libexec/firefoxpwa-connector", "755"],
 
     # Manifest
-    [
-        "manifests/linux.json",
-        "/usr/lib/mozilla/native-messaging-hosts/firefoxpwa.json",
-        "644",
-    ],
+    ["manifests/linux.json", "/usr/lib/mozilla/native-messaging-hosts/firefoxpwa.json", "644"],
 
     # Completions
-    [
-        "target/release/completions/firefoxpwa.bash",
-        "/usr/share/bash-completion/completions/firefoxpwa",
-        "644",
-    ],
-    [
-        "target/release/completions/firefoxpwa.fish",
-        "/usr/share/fish/vendor_completions.d/firefoxpwa.fish",
-        "644",
-    ],
-    [
-        "target/release/completions/_firefoxpwa",
-        "/usr/share/zsh/vendor-completions/_firefoxpwa",
-        "644",
-    ],
+    ["target/release/completions/firefoxpwa.bash", "/usr/share/bash-completion/completions/firefoxpwa", "644"],
+    ["target/release/completions/firefoxpwa.fish", "/usr/share/fish/vendor_completions.d/firefoxpwa.fish", "644"],
+    ["target/release/completions/_firefoxpwa", "/usr/share/zsh/vendor-completions/_firefoxpwa", "644"],
 
     # UserChrome
-    [
-        "userchrome/**/*",
-        "/usr/share/firefoxpwa/userchrome/",
-        "644",
-    ],
+    ["userchrome/**/*", "/usr/share/firefoxpwa/userchrome/", "644"],
 
     # Documentation
-    [
-        "../README.md",
-        "/usr/share/doc/firefoxpwa/README.md",
-        "644",
-    ],
-    [
-        "../native/README.md",
-        "/usr/share/doc/firefoxpwa/README-NATIVE.md",
-        "644",
-    ],
-    [
-        "../extension/README.md",
-        "/usr/share/doc/firefoxpwa/README-EXTENSION.md",
-        "644",
-    ],
+    ["../README.md", "/usr/share/doc/firefoxpwa/README.md", "644"],
+    ["../native/README.md", "/usr/share/doc/firefoxpwa/README-NATIVE.md", "644"],
+    ["../extension/README.md", "/usr/share/doc/firefoxpwa/README-EXTENSION.md", "644"],
 
     # AppStream Metadata
-    [
-        "packages/appstream/si.filips.FirefoxPWA.metainfo.xml",
-        "/usr/share/metainfo/si.filips.FirefoxPWA.metainfo.xml",
-        "644",
-    ],
-    [
-        "packages/appstream/si.filips.FirefoxPWA.svg",
-        "/usr/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg",
-        "644",
-    ],
+    ["packages/appstream/si.filips.FirefoxPWA.metainfo.xml", "/usr/share/metainfo/si.filips.FirefoxPWA.metainfo.xml", "644"],
+    ["packages/appstream/si.filips.FirefoxPWA.svg", "/usr/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg", "644"],
 ]
 
 [package.metadata.rpm]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -23,7 +23,6 @@ lto = true
 portable = ["dep:phf"]
 static = ["reqwest/native-tls-vendored", "bzip2/static", "xz2/static"]
 immutable-runtime = []
-linked-runtime = ["dep:blake3"]
 
 [dependencies]
 ab_glyph = "0.2.29"
@@ -39,7 +38,16 @@ fs_extra = "1.3.0"
 gag = "1.0.0"
 image = "0.25.5"
 log = "0.4.22"
-reqwest = { version = "0.12.11", features = ["blocking", "socks", "gzip", "brotli", "zstd", "deflate", "native-tls", "native-tls-alpn"] }
+reqwest = { version = "0.12.11", features = [
+    "blocking",
+    "socks",
+    "gzip",
+    "brotli",
+    "zstd",
+    "deflate",
+    "native-tls",
+    "native-tls-alpn",
+] }
 resvg = "0.44.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
@@ -71,15 +79,15 @@ features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_UI_Shell",
     "Win32_UI_Shell_Common",
-    "Win32_UI_Shell_PropertiesSystem"
+    "Win32_UI_Shell_PropertiesSystem",
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "dragonfly", target_os = "freebsd", target_os = "openbsd", target_os = "netbsd"))'.dependencies]
 glob = "0.3.2"
 phf = { version = "0.11.2", features = ["macros"] }
-blake3 = { version = "1.5.5", optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+blake3 = "1.5.5"
 bzip2 = "0.5.0"
 xz2 = "0.1.7"
 tar = "0.4.43"
@@ -100,10 +108,7 @@ ulid = "1.1.3"
 url = "2.5.4"
 
 [package.metadata.wix]
-include = [
-    "packages/wix/main.wxs",
-    "packages/wix/userchrome.wxs"
-]
+include = ["packages/wix/main.wxs", "packages/wix/userchrome.wxs"]
 
 [package.metadata.deb]
 section = "web"
@@ -116,28 +121,76 @@ license-file = "packages/deb/copyright"
 revision = ""
 assets = [
     # Executables
-    ["target/release/firefoxpwa", "/usr/bin/firefoxpwa", "755"],
-    ["target/release/firefoxpwa-connector", "/usr/libexec/firefoxpwa-connector", "755"],
+    [
+        "target/release/firefoxpwa",
+        "/usr/bin/firefoxpwa",
+        "755",
+    ],
+    [
+        "target/release/firefoxpwa-connector",
+        "/usr/libexec/firefoxpwa-connector",
+        "755",
+    ],
 
     # Manifest
-    ["manifests/linux.json", "/usr/lib/mozilla/native-messaging-hosts/firefoxpwa.json", "644"],
+    [
+        "manifests/linux.json",
+        "/usr/lib/mozilla/native-messaging-hosts/firefoxpwa.json",
+        "644",
+    ],
 
     # Completions
-    ["target/release/completions/firefoxpwa.bash", "/usr/share/bash-completion/completions/firefoxpwa", "644"],
-    ["target/release/completions/firefoxpwa.fish", "/usr/share/fish/vendor_completions.d/firefoxpwa.fish", "644"],
-    ["target/release/completions/_firefoxpwa", "/usr/share/zsh/vendor-completions/_firefoxpwa", "644"],
+    [
+        "target/release/completions/firefoxpwa.bash",
+        "/usr/share/bash-completion/completions/firefoxpwa",
+        "644",
+    ],
+    [
+        "target/release/completions/firefoxpwa.fish",
+        "/usr/share/fish/vendor_completions.d/firefoxpwa.fish",
+        "644",
+    ],
+    [
+        "target/release/completions/_firefoxpwa",
+        "/usr/share/zsh/vendor-completions/_firefoxpwa",
+        "644",
+    ],
 
     # UserChrome
-    ["userchrome/**/*", "/usr/share/firefoxpwa/userchrome/", "644"],
+    [
+        "userchrome/**/*",
+        "/usr/share/firefoxpwa/userchrome/",
+        "644",
+    ],
 
     # Documentation
-    ["../README.md", "/usr/share/doc/firefoxpwa/README.md", "644"],
-    ["../native/README.md", "/usr/share/doc/firefoxpwa/README-NATIVE.md", "644"],
-    ["../extension/README.md", "/usr/share/doc/firefoxpwa/README-EXTENSION.md", "644"],
+    [
+        "../README.md",
+        "/usr/share/doc/firefoxpwa/README.md",
+        "644",
+    ],
+    [
+        "../native/README.md",
+        "/usr/share/doc/firefoxpwa/README-NATIVE.md",
+        "644",
+    ],
+    [
+        "../extension/README.md",
+        "/usr/share/doc/firefoxpwa/README-EXTENSION.md",
+        "644",
+    ],
 
     # AppStream Metadata
-    ["packages/appstream/si.filips.FirefoxPWA.metainfo.xml", "/usr/share/metainfo/si.filips.FirefoxPWA.metainfo.xml", "644"],
-    ["packages/appstream/si.filips.FirefoxPWA.svg", "/usr/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg", "644"],
+    [
+        "packages/appstream/si.filips.FirefoxPWA.metainfo.xml",
+        "/usr/share/metainfo/si.filips.FirefoxPWA.metainfo.xml",
+        "644",
+    ],
+    [
+        "packages/appstream/si.filips.FirefoxPWA.svg",
+        "/usr/share/icons/hicolor/scalable/apps/si.filips.FirefoxPWA.svg",
+        "644",
+    ],
 ]
 
 [package.metadata.rpm]

--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -240,7 +240,7 @@ impl Runtime {
         const COPY_ERROR: &str = "Failed to copy the runtime";
         const CLEANUP_ERROR: &str = "Failed to clean up the runtime";
 
-        #[cfg(feature = "linked-runtime")]
+        #[cfg(platform_linux)]
         {
             use crate::storage::Storage;
 
@@ -352,7 +352,7 @@ impl Runtime {
         Ok(())
     }
 
-    #[cfg(feature = "linked-runtime")]
+    #[cfg(platform_linux)]
     pub fn link(&self) -> Result<()> {
         use std::fs::{copy, create_dir_all};
         use std::os::unix::fs::symlink;

--- a/native/src/connector/process.rs
+++ b/native/src/connector/process.rs
@@ -4,16 +4,36 @@ use log::{info, warn};
 
 use crate::components::runtime::Runtime;
 use crate::connector::request::{
-    CreateProfile, GetConfig, GetProfileList, GetSiteList, GetSystemVersions, InstallRuntime,
-    InstallSite, LaunchSite, PatchAllProfiles, RegisterProtocolHandler, RemoveProfile, SetConfig,
-    UninstallRuntime, UninstallSite, UnregisterProtocolHandler, UpdateAllSites, UpdateProfile,
+    CreateProfile,
+    GetConfig,
+    GetProfileList,
+    GetSiteList,
+    GetSystemVersions,
+    InstallRuntime,
+    InstallSite,
+    LaunchSite,
+    PatchAllProfiles,
+    RegisterProtocolHandler,
+    RemoveProfile,
+    SetConfig,
+    UninstallRuntime,
+    UninstallSite,
+    UnregisterProtocolHandler,
+    UpdateAllSites,
+    UpdateProfile,
     UpdateSite,
 };
 use crate::connector::response::ConnectorResponse;
 use crate::connector::Connection;
 use crate::console::app::{
-    ProfileCreateCommand, ProfileRemoveCommand, ProfileUpdateCommand, RuntimeInstallCommand,
-    RuntimeUninstallCommand, SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand,
+    ProfileCreateCommand,
+    ProfileRemoveCommand,
+    ProfileUpdateCommand,
+    RuntimeInstallCommand,
+    RuntimeUninstallCommand,
+    SiteInstallCommand,
+    SiteLaunchCommand,
+    SiteUninstallCommand,
     SiteUpdateCommand,
 };
 use crate::console::Run;

--- a/native/src/connector/process.rs
+++ b/native/src/connector/process.rs
@@ -4,36 +4,16 @@ use log::{info, warn};
 
 use crate::components::runtime::Runtime;
 use crate::connector::request::{
-    CreateProfile,
-    GetConfig,
-    GetProfileList,
-    GetSiteList,
-    GetSystemVersions,
-    InstallRuntime,
-    InstallSite,
-    LaunchSite,
-    PatchAllProfiles,
-    RegisterProtocolHandler,
-    RemoveProfile,
-    SetConfig,
-    UninstallRuntime,
-    UninstallSite,
-    UnregisterProtocolHandler,
-    UpdateAllSites,
-    UpdateProfile,
+    CreateProfile, GetConfig, GetProfileList, GetSiteList, GetSystemVersions, InstallRuntime,
+    InstallSite, LaunchSite, PatchAllProfiles, RegisterProtocolHandler, RemoveProfile, SetConfig,
+    UninstallRuntime, UninstallSite, UnregisterProtocolHandler, UpdateAllSites, UpdateProfile,
     UpdateSite,
 };
 use crate::connector::response::ConnectorResponse;
 use crate::connector::Connection;
 use crate::console::app::{
-    ProfileCreateCommand,
-    ProfileRemoveCommand,
-    ProfileUpdateCommand,
-    RuntimeInstallCommand,
-    RuntimeUninstallCommand,
-    SiteInstallCommand,
-    SiteLaunchCommand,
-    SiteUninstallCommand,
+    ProfileCreateCommand, ProfileRemoveCommand, ProfileUpdateCommand, RuntimeInstallCommand,
+    RuntimeUninstallCommand, SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand,
     SiteUpdateCommand,
 };
 use crate::console::Run;
@@ -84,7 +64,7 @@ impl Process for SetConfig {
 impl Process for InstallRuntime {
     fn process(&self, _connection: &Connection) -> Result<ConnectorResponse> {
         let command = RuntimeInstallCommand {
-            #[cfg(feature = "linked-runtime")]
+            #[cfg(platform_linux)]
             link: self.link,
         };
         command.run()?;

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -154,14 +154,14 @@ pub struct SetConfig(pub Config);
 /// [`ConnectorResponse::RuntimeInstalled`] - No data.
 ///
 
-#[cfg(feature = "linked-runtime")]
+#[cfg(platform_linux)]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime {
     /// Experimental: Use a linked runtime instead of downloading from Mozilla.
     pub link: bool,
 }
 
-#[cfg(not(feature = "linked-runtime"))]
+#[cfg(not(platform_linux))]
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime;
 
@@ -612,7 +612,7 @@ impl Into<crate::console::app::HTTPClientConfig> for HTTPClientConfig {
 
 deserialize_unit_struct!(GetSystemVersions);
 deserialize_unit_struct!(GetConfig);
-#[cfg(not(feature = "linked-runtime"))]
+#[cfg(not(platform_linux))]
 deserialize_unit_struct!(InstallRuntime);
 deserialize_unit_struct!(UninstallRuntime);
 deserialize_unit_struct!(GetSiteList);

--- a/native/src/connector/request.rs
+++ b/native/src/connector/request.rs
@@ -153,7 +153,6 @@ pub struct SetConfig(pub Config);
 ///
 /// [`ConnectorResponse::RuntimeInstalled`] - No data.
 ///
-
 #[cfg(platform_linux)]
 #[derive(Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct InstallRuntime {

--- a/native/src/console/app.rs
+++ b/native/src/console/app.rs
@@ -277,7 +277,7 @@ pub enum RuntimeCommand {
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
 pub struct RuntimeInstallCommand {
     /// Experimental: Use a linked runtime instead of downloading from Mozilla
-    #[cfg(feature = "linked-runtime")]
+    #[cfg(platform_linux)]
     #[clap(long)]
     pub link: bool,
 }

--- a/native/src/console/app.rs
+++ b/native/src/console/app.rs
@@ -277,7 +277,7 @@ pub enum RuntimeCommand {
 #[derive(Parser, Debug, Eq, PartialEq, Clone)]
 pub struct RuntimeInstallCommand {
     /// Experimental: Use a linked runtime instead of downloading from Mozilla
-    #[cfg(platform_linux)]
+    #[cfg(target_os = "linux")]
     #[clap(long)]
     pub link: bool,
 }

--- a/native/src/console/runtime.rs
+++ b/native/src/console/runtime.rs
@@ -26,14 +26,14 @@ impl Run for RuntimeInstallCommand {
         let dirs = ProjectDirs::new()?;
         let runtime = Runtime::new(&dirs)?;
 
-        #[cfg(feature = "linked-runtime")]
+        #[cfg(platform_linux)]
         if self.link {
             runtime.link().context("Failed to link runtime")?
         } else {
             runtime.install().context("Failed to install runtime")?;
         }
 
-        #[cfg(not(feature = "linked-runtime"))]
+        #[cfg(not(platform_linux))]
         runtime.install().context("Failed to install runtime")?;
 
         let runtime = Runtime::new(&dirs)?;

--- a/native/src/console/site.rs
+++ b/native/src/console/site.rs
@@ -11,10 +11,7 @@ use url::Url;
 use crate::components::runtime::Runtime;
 use crate::components::site::{Site, SiteConfig};
 use crate::console::app::{
-    SiteInstallCommand,
-    SiteLaunchCommand,
-    SiteUninstallCommand,
-    SiteUpdateCommand,
+    SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand, SiteUpdateCommand,
 };
 use crate::console::{store_value, store_value_vec, Run};
 use crate::directories::ProjectDirs;
@@ -46,7 +43,7 @@ impl Run for SiteLaunchCommand {
             bail!("Runtime not installed");
         }
 
-        #[cfg(feature = "linked-runtime")]
+        #[cfg(platform_linux)]
         {
             use std::fs::File;
             use std::io::Read;

--- a/native/src/console/site.rs
+++ b/native/src/console/site.rs
@@ -11,7 +11,10 @@ use url::Url;
 use crate::components::runtime::Runtime;
 use crate::components::site::{Site, SiteConfig};
 use crate::console::app::{
-    SiteInstallCommand, SiteLaunchCommand, SiteUninstallCommand, SiteUpdateCommand,
+    SiteInstallCommand,
+    SiteLaunchCommand,
+    SiteUninstallCommand,
+    SiteUpdateCommand,
 };
 use crate::console::{store_value, store_value_vec, Run};
 use crate::directories::ProjectDirs;

--- a/native/src/storage.rs
+++ b/native/src/storage.rs
@@ -49,7 +49,7 @@ pub struct Config {
     /// May be overwritten with a system environment variable.
     pub runtime_use_portals: bool,
 
-    #[cfg(feature = "linked-runtime")]
+    #[cfg(platform_linux)]
     /// Experimental: Using the system runtime to save some disk space.
     /// This might not work on your system.
     pub use_linked_runtime: bool,


### PR DESCRIPTION
The linked runtime feature is nice and, in my opinion, needs more testing. I thought it might be interesting to try bundling it by default in Linux builds so more people can try it and give us feedback.