### PR TITLE
fix #381

### DIFF
--- a/native/userchrome/profile/chrome/pwa/content/browser.sys.mjs
+++ b/native/userchrome/profile/chrome/pwa/content/browser.sys.mjs
@@ -432,7 +432,7 @@ class PwaBrowser {
       // Open the default browser and cancel the request for out-of-scope URLs
       if (checkOutOfScope(httpChannel.URI, chromeWindow)) {
         MailIntegration._launchExternalUrl(httpChannel.URI);
-        httpChannel.cancel(418);
+        httpChannel.cancel(Cr.NS_BINDING_ABORTED);
       }
     }, 'http-on-modify-request', false);
 


### PR DESCRIPTION
still restarts websockets, which is not ideal, but it makes firefox pwas usable

I have no idea how anything works, or why it does what it does, but I saw someone on stackoverflow using `Cr.NS_BINDING_ABORTED` and tested that and it works for me

https://stackoverflow.com/questions/30585385/firefox-extension-how-to-intercept-the-requested-url-conditionally-and-block-it