### PR TITLE
Clarify allowed domains format in preference description

### DIFF
--- a/native/userchrome/profile/chrome/pwa/content/preferences.sys.mjs
+++ b/native/userchrome/profile/chrome/pwa/content/preferences.sys.mjs
@@ -115,6 +115,7 @@ class PwaPreferences {
   <vbox id="allowedDomainsBox" style="padding-top: 1rem;">
     <label>
       <description data-l10n-id="allowed-domains-description"></description>
+      <description data-l10n-id="allowed-domains-format"></description>
     </label>
     <vbox>
       <html:input type="text" class="global-input" preference="${ChromeLoader.PREF_ALLOWED_DOMAINS}" data-l10n-id="allowed-domains-input" />

--- a/native/userchrome/profile/chrome/pwa/localization/en-US/pwa/preferences.ftl
+++ b/native/userchrome/profile/chrome/pwa/localization/en-US/pwa/preferences.ftl
@@ -80,7 +80,9 @@ display-address-bar-choice-never =
 
 ## Allowed Domains Preference
 
-allowed-domains-description = Comma-separated list of domains always allowed to be opened in the app browser (e.g. example.com,*.example.com)
+allowed-domains-description = Domains always allowed to be opened in the app browser
+
+allowed-domains-format = Enter a comma-separated list of domains (e.g. example.com,*.example.com)
 
 allowed-domains-input =
     .placeholder = example.com,*.example.com

--- a/native/userchrome/profile/chrome/pwa/localization/sl/pwa/preferences.ftl
+++ b/native/userchrome/profile/chrome/pwa/localization/sl/pwa/preferences.ftl
@@ -65,8 +65,9 @@ display-address-bar-choice-never =
 ## Allowed Domains Preference
 
 allowed-domains-description = Domene, ki so vedno lahko odprte v aplikaciji
+allowed-domains-format = Vnesite seznam domen, ločenih z vejico (npr. example.com,*.example.com)
 allowed-domains-input =
-    .placeholder = Vnesite seznam domen, ločenih z vejico ...
+    .placeholder = example.com,*.example.com
 
 ## Keyboard Shortcuts Group Details
 


### PR DESCRIPTION
Mention comma-separated format and wildcard support in the description label so users don't need to inspect source code.