### PR TITLE
feat(native): support firefox-esr for runtime install --link

### DIFF
--- a/native/src/components/runtime.rs
+++ b/native/src/components/runtime.rs
@@ -13,8 +13,28 @@ use tempfile::{NamedTempFile, TempDir};
 use crate::components::site::Site;
 use crate::directories::ProjectDirs;
 
-// TODO: Remove this constant and implement variable firefox path into user documentation
-pub const FFOX: &str = "/usr/lib/firefox/";
+pub const FFOX_PATHS: [&str; 2] = ["/usr/lib/firefox/", "/usr/lib/firefox-esr/"];
+pub const FFOX_BINS: [&str; 2] = ["firefox", "firefox-esr"];
+
+// Returns the first system Firefox directory that exists,
+// or the first candidate if none of them exist
+#[inline]
+pub fn ffox() -> &'static str {
+    FFOX_PATHS.into_iter().find(|path| Path::new(path).exists()).unwrap_or(FFOX_PATHS[0])
+}
+
+// Returns the first Firefox binary that exists in ffox() dir,
+// or the first candidate if none of them exist
+#[inline]
+pub fn ffox_binary() -> &'static str {
+    FFOX_BINS.into_iter().find(|name| Path::new(ffox()).join(name).exists()).unwrap_or(FFOX_BINS[0])
+}
+
+// Returns full path to Firefox launcher
+#[inline]
+pub fn ffox_launcher() -> PathBuf {
+    Path::new(ffox()).join(ffox_binary())
+}
 
 cfg_if! {
     if #[cfg(any(platform_linux, platform_bsd))] {
@@ -357,8 +377,8 @@ impl Runtime {
 
         info!("Linking the runtime");
 
-        if Path::new(FFOX).exists() {
-            for entry in read_dir(FFOX)?.flatten() {
+        if Path::new(ffox()).exists() {
+            for entry in read_dir(ffox())?.flatten() {
                 let entry = entry.path();
                 match entry.file_name().expect("Couldn't retrieve a file name").to_str() {
                     // Use a different branch for the "defaults" folder due to the patches to apply afterwhile
@@ -372,8 +392,10 @@ impl Runtime {
                     Some("firefox-bin") => {
                         copy(entry, self.directory.join("firefox-bin"))?;
                     }
-                    Some("firefox") => {
-                        copy(entry, self.directory.join("firefox"))?;
+                    Some(name) if FFOX_BINS.contains(&name) => {
+                        if entry == ffox_launcher() {
+                            copy(entry, self.directory.join("firefox"))?;
+                        }
                     }
                     Some(&_) => {
                         let link = self.directory.join(entry.file_name().unwrap());

--- a/native/src/console/site.rs
+++ b/native/src/console/site.rs
@@ -55,7 +55,7 @@ impl Run for SiteLaunchCommand {
             use blake3::{Hash, hash};
 
             fn hasher<P: AsRef<Path>>(path: P) -> Hash {
-                let mut file = File::open(path.as_ref().join("firefox")).unwrap();
+                let mut file = File::open(path).unwrap();
                 let mut buf = Vec::new();
                 let _ = file.read_to_end(&mut buf);
 
@@ -63,7 +63,8 @@ impl Run for SiteLaunchCommand {
             }
 
             if storage.config.use_linked_runtime
-                && hasher(crate::components::runtime::FFOX) != hasher(&runtime.directory)
+                && hasher(crate::components::runtime::ffox_launcher())
+                    != hasher(runtime.directory.join("firefox"))
             {
                 runtime.link()?;
             }


### PR DESCRIPTION
On Debian `firefox-esr `package stores firefox binaries in `/usr/lib/firefox-esr` and names main binary `firefox-esr`. This PR check also for this location.

This works for me, but `about:preferences` menu crashes, probably because of ebe88cba3e52def5cebfba5a4bb3d04f876cd329 and Debian still ships ESR 140. New ESR is 153 and probably soon be packaged, and everything else works, so it's fine anyway.